### PR TITLE
Throwing exception for corrupted files.

### DIFF
--- a/src/Products/Comparison/Service/ComparisonServiceImpl.cs
+++ b/src/Products/Comparison/Service/ComparisonServiceImpl.cs
@@ -110,6 +110,10 @@ namespace GroupDocs.Comparison.MVC.Products.Comparison.Service
             {
                 Dictionary<int, string> pagesContent = new Dictionary<int, string>();
                 IDocumentInfo documentInfo = comparer.Source.GetDocumentInfo();
+                if (documentInfo.PagesInfo == null) 
+                {
+                    throw new GroupDocs.Comparison.Common.Exceptions.ComparisonException("File is corrupted.");
+                }
 
                 if (loadAllPages)
                 {


### PR DESCRIPTION
**Problem:**
We would like to show more correct error message when user tried to open corrupted file. 

**Solution:**
Was added exception throwing with relevant message.

**Screenshots:**
_Before:_
![image](https://user-images.githubusercontent.com/17431807/95375553-77c89100-08e8-11eb-96cc-6cb1b653e62d.png)

_After:_
![image](https://user-images.githubusercontent.com/17431807/95375755-bcecc300-08e8-11eb-91d8-628e60141e6c.png)